### PR TITLE
Better face support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ More explicitly, the following data will be prioritized:
 | Geometric Vertex | `v`                   | `v x y z [w]`    | The `x`, `y`, and `z` components of the vertex, and an optional `w` component (the weight), assumed to be 1.0 if not provided|
 | Vertex Texture   | `vt`                  | `vt u [v w]`     | A horizontal texture direction `u`, an optional vertical texture direction `v` (default of 0), and an optional depth `w` (default of 0)|
 | Vertex Normal    | `vn`                  | `vn i j k`       | A normal vector with components `i`, `j`, and `k` |
-| Face Elements    | `f`                   | `f v1[/[vt1]/vn1] v2[/[vt2]/vn2] v3[/[vt3]/vn3]`| A face constructed from vertices of index `v1`, `v2`, and `v3`, with optional texture indices `vt1`, `vt2`, and `vt3`, and optional normal indices `vn1`, `vn2`, and `vn3`|
+| Face Elements    | `f`                   | `f v1[/[vt1][/vn1]] v2[/[vt2][/vn2]] v3[/[vt3][/vn3]] ...`| A face constructed from vertices of index `v1`, `v2`, `...`, with optional texture indices `vt1`, `vt2`, `...``, and optional normal indices `vn1`, `vn2`, `...`|
 
 Notably lacking (for now) are line elements (`l v1 v2 v3 v4 ...`), parameter space vertices (`vp u [w] [v]`), or any 
 material support (`.mtl` files). While these may be in the scope for future work on this project, in beginning 

--- a/modules/face.lua
+++ b/modules/face.lua
@@ -18,11 +18,10 @@ end
 -- @tparam {number,...} vn Vertex normal indices of the form {vn1, vn2, vn3}
 function face.new(v, vt, vn)
 	assert(type(v) == "table", "new: Argument v should be of type <table>")
-	assert(#v == 3, "new: Wavedash does not support faces with greater than three vertices")
 
-	assert(type(v[1]) == "number", "new: Argument v members must be of type <number>")
-	assert(type(v[2]) == "number", "new: Argument v members must be of type <number>")
-	assert(type(v[3]) == "number", "new: Argument v members must be of type <number>")
+	for i=1, #v do
+		assert(type(v[i]) == "number", "new Argument v members must be of type <number>")
+	end
 
 	if vt ~= nil then
 		assert(type(vt) == "table", "new: Argument vt should be of type <table>")

--- a/modules/object.lua
+++ b/modules/object.lua
@@ -95,7 +95,14 @@ function object.parse(filepath)
 	return new(verts, norms, texcoords, faces, found_unsupported)
 end
 
---- Iterator to traverse the vertices in face order of an object
+--- Iterator to traverse the vertices in face order of an object.
+--
+-- Intended to be used for functions that require faces be constructed by vertices passed in-order, the iterator 
+-- returned by this function will provide three-tuples of vertices corresponding to the face (or subface) next 
+-- described by the object. Subfaces are generated only in this function, and are not properties of the face module.
+-- Subfaces are generated for all faces with n>3 vertices, and will create subfaces of vertices 1, f+1, f+2, where f 
+-- is the 1-indexed subface number. By this process, a quadrilateral face would be broken into two triangular subfaces
+-- of vertices 1, 2, 3 and 1, 3, 4 respectively. 
 -- @tparam object o Object whose faces through which to iterate
 -- @return the iterator
 function object.verts_in_order(o)

--- a/modules/object.lua
+++ b/modules/object.lua
@@ -47,7 +47,14 @@ function object.parse(filepath)
 
 		out[outField] = toSplit:sub(start)
 
-		return out
+		local stripped_out = {}
+		for i=1, #out do
+			if out[i] ~= "" then
+				stripped_out[#stripped_out+1] = out[i]
+			end
+		end
+
+		return stripped_out
 	end
 
 	-- Create local tables for each of our supported datapoints


### PR DESCRIPTION
Enables parsing of files that have face elements (`f`) constructed from more than three `v/vt/vn` sets.

- Updated the `verts_in_order` function of the `object` module to present "subfaces" of these polygonal faces by presenting vertices in the form `1, f+1, f+2` where `f` is the index of the created subface, starting at 1, and assuming vertices are presented in clockwise order

```
v2      v3
  *----*
  | 1 /|
  |  / |
  | /  |
  |/ 2 |
  *----*
v1      v4
```
This results in subface 1 being created with vertices `v1`, `v2`, and `v3`, and subface 2 created with vertices `v1`, `v3`, and `v4`.